### PR TITLE
271 remove date from xml script

### DIFF
--- a/scripts/create_master_lists.py
+++ b/scripts/create_master_lists.py
@@ -35,7 +35,7 @@ class CSVWriter:
     
 class XMLWriter:
 
-    xmlheader = '<dataroot xmlns:od="urn:schemas-microsoft-com:officedata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" generated="{}">'.format( datetime.now().isoformat() )
+    xmlheader = '<dataroot xmlns:od="urn:schemas-microsoft-com:officedata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
 
 
     def __init__(self,outfile,elements,item_name):

--- a/xml/CodeFlag.xml
+++ b/xml/CodeFlag.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<dataroot xmlns:od="urn:schemas-microsoft-com:officedata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" generated="2024-06-25T13:47:54.832108">
+<dataroot xmlns:od="urn:schemas-microsoft-com:officedata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" generated="2024-07-10T13:50:37.046728">
 	<GRIB2_CodeFlag_en>
 		<Title_en>Code table 0.0 - Discipline of processed data in the GRIB message, number of GRIB Master table</Title_en>
 		<CodeFlag>0</CodeFlag>

--- a/xml/CodeFlag.xml
+++ b/xml/CodeFlag.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<dataroot xmlns:od="urn:schemas-microsoft-com:officedata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" generated="2024-07-10T13:50:37.046728">
+<dataroot xmlns:od="urn:schemas-microsoft-com:officedata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<GRIB2_CodeFlag_en>
 		<Title_en>Code table 0.0 - Discipline of processed data in the GRIB message, number of GRIB Master table</Title_en>
 		<CodeFlag>0</CodeFlag>

--- a/xml/Template.xml
+++ b/xml/Template.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<dataroot xmlns:od="urn:schemas-microsoft-com:officedata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" generated="2024-06-25T13:47:54.832108">
+<dataroot xmlns:od="urn:schemas-microsoft-com:officedata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" generated="2024-07-10T13:50:37.046728">
 	<GRIB2_Template_en>
 		<Title_en>Identification template 1.0 - calendar definition</Title_en>
 		<OctetNo>24</OctetNo>

--- a/xml/Template.xml
+++ b/xml/Template.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<dataroot xmlns:od="urn:schemas-microsoft-com:officedata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" generated="2024-07-10T13:50:37.046728">
+<dataroot xmlns:od="urn:schemas-microsoft-com:officedata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<GRIB2_Template_en>
 		<Title_en>Identification template 1.0 - calendar definition</Title_en>
 		<OctetNo>24</OctetNo>


### PR DESCRIPTION
Remove the generation of the 'generated' param to avoid complex merging process.

Now the xml header won't have the 'generated' param anymore